### PR TITLE
Support querying info about VPC security groups

### DIFF
--- a/src/Network/AWS/EC2.hs
+++ b/src/Network/AWS/EC2.hs
@@ -3851,6 +3851,7 @@ instance IsXML DescribeRegionsResponse where
 data DescribeSecurityGroups = DescribeSecurityGroups
     { dshGroupName :: [Text]
       -- ^ A list of group names.
+      -- NB: doesn't work for non-default VPCs, use 'dshFilter' instead.
     , dshGroupId   :: [Text]
       -- ^ A list of group ids.
     , dshFilter    :: [Filter]

--- a/src/Network/AWS/EC2/Types.hs
+++ b/src/Network/AWS/EC2/Types.hs
@@ -71,19 +71,21 @@ instance ToError EC2ErrorResponse where
 
 instance IsXML EC2ErrorResponse
 
-data Protocol = TCP | UDP | ICMP
+data Protocol = TCP | UDP | ICMP | AnyProtocol
     deriving (Eq, Ord, Generic)
 
 instance Show Protocol where
     show TCP  = "tcp"
     show UDP  = "udp"
     show ICMP = "icmp"
+    show AnyProtocol = "-1"
 
 instance Read Protocol where
     readPrec = readAssocList
         [ ("tcp",  TCP)
         , ("udp",  UDP)
         , ("icmp", ICMP)
+        , ("-1",   AnyProtocol)
         ]
 
 instance IsQuery Protocol where
@@ -1328,10 +1330,10 @@ instance IsXML UserIdGroupPair where
 data IpPermissionType = IpPermissionType
     { iptIpProtocol :: !Protocol
       -- ^ The protocol.
-    , iptFromPort   :: !Integer
+    , iptFromPort   :: !(Maybe Integer)
       -- ^ The start of port range for the ICMP and UDP protocols, or an ICMP
       -- type number. A value of -1 indicates all ICMP types.
-    , iptToPort     :: !Integer
+    , iptToPort     :: !(Maybe Integer)
       -- ^ The end of port range for the ICMP and UDP protocols, or an ICMP
       -- code. A value of -1 indicates all ICMP codes for the given ICMP type.
     , iptGroups     :: [UserIdGroupPair]


### PR DESCRIPTION
The info about VPC security groups that AWS returns doesn't fit the existing schema that amazonka-limited uses. The schema has to be extended.